### PR TITLE
Nissix plugin scope-packages on wix-ui-tpa-connected-css-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -783,6 +783,14 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wix/wix-ui-tpa-connected": {
+      "version": "2.0.4",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/wix-ui-tpa-connected/-/@wix/wix-ui-tpa-connected-2.0.4.tgz",
+      "integrity": "sha1-5zFFOmr5szd1lDomcyghsoQEn+k=",
+      "requires": {
+        "wix-ui-tpa-analyser": "^1.0.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -7615,14 +7623,6 @@
         "args": "~5.0.1",
         "find-node-modules": "^2.0.0",
         "json-beautify": "^1.1.0"
-      }
-    },
-    "wix-ui-tpa-connected": {
-      "version": "2.0.3",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wix-ui-tpa-connected/-/wix-ui-tpa-connected-2.0.3.tgz",
-      "integrity": "sha1-l2chovxp+9JSRC8ZwQXQMJClf58=",
-      "requires": {
-        "wix-ui-tpa-analyser": "^1.0.0"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "args": "^5.0.1",
     "find-node-module": "^1.0.0",
-    "wix-ui-tpa-connected": "^2.0.2"
+    "@wix/wix-ui-tpa-connected": "^2.0.2"
   },
   "devDependencies": {
     "@types/args": "^3.0.0",


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.421s



Output Log:
Migrating package "wix-ui-tpa-connected-css-builder" in .


## Migration from non scope to @wix/scoped packages
> /tmp/e9ef0d41c7eb44805a12c6a91ca53f92

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```
added 138 packages from 116 contributors and audited 853 packages in 4.929s
found 39135 vulnerabilities (39121 low, 2 moderate, 12 high)
  run `npm audit fix` to fix them, or `npm audit` for details

